### PR TITLE
問題と答えの編集機能を実装

### DIFF
--- a/resources/struts.xml
+++ b/resources/struts.xml
@@ -44,5 +44,9 @@
 			<result name="success">/list.jsp</result>
 			<result name="failure">/login.jsp</result>
 		</action>
+		<action name="edit" class="kensyu3.controller.QuestionsAnswersAction" method="edit">
+			<result name="success">/edit.jsp</result>
+			<result name="failure">/login.jsp</result>
+		</action>
 	</package>
 </struts>

--- a/resources/struts.xml
+++ b/resources/struts.xml
@@ -52,5 +52,9 @@
 			<result name="success">/edit_confirm.jsp</result>
 			<result name="failure">/login.jsp</result>
 		</action>
+		<action name="edit_complete" class="kensyu3.controller.QuestionsAnswersAction" method="edit_complete">
+			<result name="success">/list.jsp</result>
+			<result name="failure">/login.jsp</result>
+		</action>
 	</package>
 </struts>

--- a/resources/struts.xml
+++ b/resources/struts.xml
@@ -48,5 +48,9 @@
 			<result name="success">/edit.jsp</result>
 			<result name="failure">/login.jsp</result>
 		</action>
+		<action name="edit_confirm" class="kensyu3.controller.QuestionsAnswersAction" method="edit_confirm">
+			<result name="success">/edit_confirm.jsp</result>
+			<result name="failure">/login.jsp</result>
+		</action>
 	</package>
 </struts>

--- a/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
+++ b/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
@@ -151,9 +151,9 @@ public class QuestionsAnswersAction extends Base{
 			for(int i = 0; i < inputAnswers.length; i++) {
 				if( i < answersId.length) { //入力された答えの中に、idを持つものがあった場合（更新された答えがあった場合）
 					//idをもとにDBに登録されている答えデータを取得
-					AnswersBean tmp_answer = ansDao.findById(answersId[i]);
+					AnswersBean tmpAnswer = ansDao.findById(answersId[i]);
 					//入力された答えと、DBに登録されている答えの内容が一致していなかった場合
-					if(!(inputAnswers[i].equals(tmp_answer.getAnswer()))) {
+					if(!(inputAnswers[i].equals(tmpAnswer.getAnswer()))) {
 						ansDao.update_answer(answersId[i], inputAnswers[i]); //答えを更新
 					}
 				} else { //idを持たない答えがあった場合（新たに追加された答えがあった場合）
@@ -276,6 +276,7 @@ public class QuestionsAnswersAction extends Base{
 	}
 	
 	public void setAnswersId(String answersId) {
+		//answersIdを配列にして、int型に変換
 		this.answersId = Stream.of(answersId.split(", ")).mapToInt(Integer::parseInt).toArray();
 	}
 }

--- a/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
+++ b/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
@@ -144,13 +144,18 @@ public class QuestionsAnswersAction extends Base{
 			//問題を編集
 			queDao.update(inputQuestion,questionId);
 			
-			//問題idから答えデータを取得
+			//問題idからDBに登録されている答えデータを取得
 			ArrayList<AnswersBean> aList = ansDao.findByQuestionId(questionId);
 			
-			//フォームから渡された答えの数だけ処理を繰り返す
+			//入力された答えの数だけ処理を繰り返す
 			for(int i = 0; i < inputAnswers.length; i++) {
-				if( i < answersId.length) { //フォームから渡された答えの中に、idを持つものがあった場合（更新された答えがあった場合）
-					ansDao.update_answer(answersId[i], inputAnswers[i]); //答えを更新
+				if( i < answersId.length) { //入力された答えの中に、idを持つものがあった場合（更新された答えがあった場合）
+					//idをもとにDBに登録されている答えデータを取得
+					AnswersBean tmp_answer = ansDao.findById(answersId[i]);
+					//入力された答えと、DBに登録されている答えの内容が一致していなかった場合
+					if(!(inputAnswers[i].equals(tmp_answer.getAnswer()))) {
+						ansDao.update_answer(answersId[i], inputAnswers[i]); //答えを更新
+					}
 				} else { //idを持たない答えがあった場合（新たに追加された答えがあった場合）
 					ansDao.register_answer(questionId, inputAnswers[i]); //答えを登録
 				}

--- a/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
+++ b/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
@@ -1,6 +1,8 @@
 package kensyu3.controller;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.stream.Stream;
 
 import kensyu3.model.AnswersBean;
 import kensyu3.model.AnswersDao;
@@ -18,6 +20,7 @@ public class QuestionsAnswersAction extends Base{
 	private int questionId;
 	private String question;
 	private String[] answers;
+	private int[] answersId;
 	
 	//list画面を表示
 	public String list() throws Exception{
@@ -132,6 +135,41 @@ public class QuestionsAnswersAction extends Base{
 		}
 	}
 	
+	//編集処理
+	public String edit_complete() throws Exception{
+		//Baseクラスでログインしているかどうかを確認
+		if (super.isCheckLogin()) {
+			QuestionsDao queDao = new QuestionsDao();
+			AnswersDao ansDao = new AnswersDao();
+			//問題を編集
+			queDao.update(inputQuestion,questionId);
+			
+			//問題idから答えデータを取得
+			ArrayList<AnswersBean> aList = ansDao.findByQuestionId(questionId);
+			
+			//フォームから渡された答えの数だけ処理を繰り返す
+			for(int i = 0; i < inputAnswers.length; i++) {
+				if( i < answersId.length) { //フォームから渡された答えの中に、idを持つものがあった場合（更新された答えがあった場合）
+					ansDao.update_answer(answersId[i], inputAnswers[i]); //答えを更新
+				} else { //idを持たない答えがあった場合（新たに追加された答えがあった場合）
+					ansDao.register_answer(questionId, inputAnswers[i]); //答えを登録
+				}
+			}
+			if(aList.size() > answersId.length) { //既存の答えの数の方が、フォームから渡されたidの数より多かった場合（削除された答えがあった場合）
+				for(AnswersBean ans : aList) { //既存の答えの数だけ、処理を繰り返す
+					if(!(Arrays.stream(answersId).anyMatch(x -> x == ans.getId()))){ //既存の答えにしかないidがあった場合
+						ansDao.delete_answer(ans.getId()); //答えを削除
+					}
+				}
+			}
+			//list画面に遷移
+			return "success";
+		}else {
+			//login画面に遷移
+			return "failure";
+		}
+	}
+	
 	public ArrayList<QuestionsBean> getQueList() throws Exception {
 		//queListが空だった場合
 		if (queList.isEmpty()) {
@@ -203,14 +241,36 @@ public class QuestionsAnswersAction extends Base{
 			//questionIdから答えのデータを取得
 			ArrayList<AnswersBean> ans = ansDao.findByQuestionId(questionId);
 			//答えを一時的に入れる配列
-			String[] tempAnswers = new String[ans.size()];
+			String[] tmpAnswers = new String[ans.size()];
 			for(int i = 0; i < ans.size(); i++) {
 				//答えデータから答えを取得し、配列に格納
-				tempAnswers[i] = ans.get(i).getAnswer();
+				tmpAnswers[i] = ans.get(i).getAnswer();
 			}
 			//aanswersに配列になっている答えを入れ直す
-			answers = tempAnswers;
+			answers = tmpAnswers;
 		}
 		return answers;
+	}
+	
+	public int[] getAnswersId() throws Exception{
+		//answersIdが0だった場合
+		if (answersId == null) {
+			AnswersDao ansDao = new AnswersDao();
+			//questionIdから答えデータを取得
+			ArrayList<AnswersBean> ans = ansDao.findByQuestionId(questionId);
+			//答えidを一時的に入れる配列
+			int[] tmpAnswersId = new int[ans.size()];
+			for(int i = 0; i < ans.size(); i++) {
+				//答えデータから答えを取得し、配列に格納
+				tmpAnswersId[i] = ans.get(i).getId();
+			}
+			//aanswersに配列になっている答えを入れ直す
+			answersId = tmpAnswersId;
+		}
+		return answersId;
+	}
+	
+	public void setAnswersId(String answersId) {
+		this.answersId = Stream.of(answersId.split(", ")).mapToInt(Integer::parseInt).toArray();
 	}
 }

--- a/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
+++ b/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
@@ -117,6 +117,21 @@ public class QuestionsAnswersAction extends Base{
 		}
 	}
 	
+	//編集確認画面を表示
+	public String edit_confirm(){
+		//Baseクラスでログインしているかどうかを確認
+		if (super.isCheckLogin()) {
+			Validation val = new Validation();
+			//問題や答えにエラーがないか確認し、エラーメッセージに値を格納
+			errorMessage = val.validate(inputQuestion, inputAnswers);
+			//edit画面に遷移
+			return "success";
+		}else {
+			//login画面に遷移
+			return "failure";
+		}
+	}
+	
 	public ArrayList<QuestionsBean> getQueList() throws Exception {
 		//queListが空だった場合
 		if (queList.isEmpty()) {

--- a/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
+++ b/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
@@ -105,6 +105,18 @@ public class QuestionsAnswersAction extends Base{
 		}
 	}
 	
+	//編集画面を表示
+	public String edit(){
+		//Baseクラスでログインしているかどうかを確認
+		if (super.isCheckLogin()) {
+			//edit画面に遷移
+			return "success";
+		}else {
+			//login画面に遷移
+			return "failure";
+		}
+	}
+	
 	public ArrayList<QuestionsBean> getQueList() throws Exception {
 		//queListが空だった場合
 		if (queList.isEmpty()) {

--- a/src/main/java/kensyu3/model/AnswersDao.java
+++ b/src/main/java/kensyu3/model/AnswersDao.java
@@ -133,6 +133,46 @@ public class AnswersDao extends ConnectionDao {
 	}
 	
 	/**
+	 *  指定idのレコードを取得する
+	 */
+	public AnswersBean findById(int answerId) throws Exception {
+		//DBと接続がない場合、接続
+		if (con == null) {
+			setConnection();
+		}
+		//correct_answers からidとquestions_id、answerを取得（条件：idが一致するもの）
+		String sql = "SELECT id, questions_id, answer FROM correct_answers WHERE id = ? ";
+		
+		/** PreparedStatement オブジェクトの取得**/
+		try(PreparedStatement st = con.prepareStatement(sql)) {
+			//sqlの ? に値をセット
+			st.setInt(1, answerId);
+			/** SQL 実行 **/
+			ResultSet rs = st.executeQuery();
+			/** select文の結果をオブジェクトに格納 **/ 
+			AnswersBean bean = new AnswersBean();
+			//実行結果を1行ずつ読み込む
+			while (rs.next()) {
+				//実行結果からデータを取得し、各フィールドに格納
+				int id = rs.getInt("id");
+				String answer = rs.getString("answer");
+				int questions_id = rs.getInt("questions_id");
+				//オブジェクトに実行結果を格納
+				bean.setId(id);
+				bean.setAnswer(answer);
+				bean.setQuestionsId(questions_id);
+			}
+			//オブジェクトを返す
+			return bean;
+		} catch (Exception e) {
+			//スタックトレースを出力
+			e.printStackTrace();
+			//例外を投げる
+			throw new DAOException("レコードの取得に失敗しました");
+		}
+	}
+	
+	/**
 	 * 答えを登録する
 	*/
 	public void register(int questionId, String[] answers) throws Exception {

--- a/src/main/webapp/edit.jsp
+++ b/src/main/webapp/edit.jsp
@@ -1,0 +1,90 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<!-- Struts2のタグライブラリを使用可能にする -->
+<%@ taglib prefix="s" uri="/struts-tags"%>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<title>edit</title>
+		<style type="text/css">
+			body {width: 650px; margin: 0 auto;}
+			p {margin: 0;}
+			.btn_area, .bottom_menu_area {width: 100%; text-align: right;}
+			.bottom_btn_area {text-align: right; margin-top: 10px;}
+			label {margin-right: 10px;}
+			.question_form_area {margin-top: 20px; display: flex;}
+			.question_form_area textarea {width: 76.7%; height: 100px;}
+			.question_form_area label {width: 7%;}
+			.answer_forms_area {margin-top: 20px; display: flex;}
+			.answer_forms_area label {width: 7%;;}
+			.answer_forms {width: 90%;}
+			.answer_form {display: flex; margin-bottom: 10px; height: 26px;}
+			.answer_form input {display: block; width: 85%;}
+			.answer_form button {display: block; margin-left: 10px;}
+			.question_id_area {display: flex;}
+			.question_id_area label {width: 11%; text-align: right;}
+		</style>
+		<script type="text/javascript">
+			var i = 1;
+			function addForm() {
+				//答えのフォームとボタンを含むdivタグを作成
+				var answer_form = document.createElement('div');
+				answer_form.className = "answer_form"
+				answer_form.id = "answer_form" + ++i;
+				//答えの入力フォームを作成
+				var input = document.createElement('input');
+				input.type = 'text';
+				input.name = 'answers';
+				//削除ボタンを作成
+				var delete_btn = document.createElement('button');
+				delete_btn.type = 'button';
+				var function_name = 'deleteForm(' + answer_form.id + ')';
+				delete_btn.setAttribute('onclick', function_name);
+				var text = document.createTextNode('削除');
+				//答えのフォームリストを含むタグを取得
+				var parent = document.querySelector('.answer_forms');
+				//フォームリストの中にdivタグを追加
+				parent.appendChild(answer_form);
+				//divタグの中に答えの入力フォームを追加
+				answer_form.appendChild(input);
+				//divタグの中に削除ボタンを追加
+				answer_form.appendChild(delete_btn);
+				//削除ボタンにテキストを追加
+				delete_btn.appendChild(text);
+			};
+			function deleteForm(e) {	
+				//答えのフォームと削除ボタンを削除
+				e.remove();
+			};
+		</script>
+	</head>
+	<body>
+		<div class="btn_area">
+			<a href="<s:url action='top'/>"><button>top</button></a>
+			<a href="<s:url action='logout'/>"><button>logout</button></a>
+		</div>
+			<s:form action="edit_confirm">
+			<div class="question_form_area">
+				<label>問題番号:</label>
+				<p><s:property value="questionId"/></p>
+			</div>
+			<div class="question_form_area">
+				<label for="inputQuestion">問題:</label>
+				<s:textarea name="inputQuestion"/>
+			</div>
+			<div class="answer_forms_area">
+				<label for="inputAnswers">答え:</label>
+				<div class="answer_forms">
+					<div class="answer_form" id="answer_form1">
+						<s:textfield name = "inputAnswers"/>
+					</div>
+				</div>
+			</div>
+			<div class="bottom_btn_area">
+				<button type="button" onclick="history.back()">戻る</button>
+				<s:submit value = "確認"/>
+				<button type="button" onclick="addForm()">追加</button>
+			</div>
+		</s:form>
+	</body>
+</html>

--- a/src/main/webapp/edit.jsp
+++ b/src/main/webapp/edit.jsp
@@ -24,8 +24,9 @@
 			.question_id_area {display: flex;}
 			.question_id_area label {width: 11%; text-align: right;}
 		</style>
+		<s:set var="answer_length" value="answers.length"/>
 		<script type="text/javascript">
-			var i = 1;
+			var i = ${answer_length};
 			function addForm() {
 				//答えのフォームとボタンを含むdivタグを作成
 				var answer_form = document.createElement('div');
@@ -70,14 +71,20 @@
 			</div>
 			<div class="question_form_area">
 				<label for="inputQuestion">問題:</label>
-				<s:textarea name="inputQuestion"/>
+				<s:textarea name="inputQuestion" value="%{question}"/>
 			</div>
 			<div class="answer_forms_area">
 				<label for="inputAnswers">答え:</label>
 				<div class="answer_forms">
-					<div class="answer_form" id="answer_form1">
-						<s:textfield name = "inputAnswers"/>
-					</div>
+					<s:iterator value="answers" status="ansSt">
+						<div class="answer_form" id="answer_form${ansSt.count}">
+							<s:textfield name="inputAnswers" value="%{answers[#ansSt.index]}" />
+							<s:hidden name="answersId" value="%{answersId[#ansSt.index]}" />
+							<s:if test="%{#ansSt.index != 0}">
+								<button type="button" onclick="deleteForm(answer_form%{#ansSt.index + 1})">削除</button>
+							</s:if>
+						</div>
+					</s:iterator>
 				</div>
 			</div>
 			<div class="bottom_btn_area">

--- a/src/main/webapp/edit.jsp
+++ b/src/main/webapp/edit.jsp
@@ -64,7 +64,7 @@
 			<a href="<s:url action='logout'/>"><button>logout</button></a>
 		</div>
 			<s:form action="edit_confirm">
-			<div class="question_form_area">
+			<div class="question_id_area">
 				<label>問題番号:</label>
 				<p><s:property value="questionId"/></p>
 			</div>

--- a/src/main/webapp/edit.jsp
+++ b/src/main/webapp/edit.jsp
@@ -82,6 +82,7 @@
 						<div class="answer_form" id="answer_form${ansSt.count}">
 							<s:textfield name="inputAnswers" value="%{answers[#ansSt.index]}" />
 							<s:hidden name="answersId" value="%{answersId[#ansSt.index]}" />
+							<!-- 2つ目以降に表示されている答えフォームには削除ボタンを設置 -->
 							<s:if test="%{#ansSt.index != 0}">
 								<button type="button" onclick="deleteForm(answer_form${ansSt.count})">削除</button>
 							</s:if>

--- a/src/main/webapp/edit.jsp
+++ b/src/main/webapp/edit.jsp
@@ -83,7 +83,7 @@
 							<s:textfield name="inputAnswers" value="%{answers[#ansSt.index]}" />
 							<s:hidden name="answersId" value="%{answersId[#ansSt.index]}" />
 							<s:if test="%{#ansSt.index != 0}">
-								<button type="button" onclick="deleteForm(answer_form%{#ansSt.index + 1})">削除</button>
+								<button type="button" onclick="deleteForm(answer_form${ansSt.count})">削除</button>
 							</s:if>
 						</div>
 					</s:iterator>

--- a/src/main/webapp/edit.jsp
+++ b/src/main/webapp/edit.jsp
@@ -26,6 +26,7 @@
 		</style>
 		<s:set var="answer_length" value="answers.length"/>
 		<script type="text/javascript">
+			//iの初期値を答えの数に設定
 			var i = ${answer_length};
 			function addForm() {
 				//答えのフォームとボタンを含むdivタグを作成
@@ -35,7 +36,7 @@
 				//答えの入力フォームを作成
 				var input = document.createElement('input');
 				input.type = 'text';
-				input.name = 'answers';
+				input.name = 'inputAnswers';
 				//削除ボタンを作成
 				var delete_btn = document.createElement('button');
 				delete_btn.type = 'button';
@@ -64,10 +65,11 @@
 			<a href="<s:url action='top'/>"><button>top</button></a>
 			<a href="<s:url action='logout'/>"><button>logout</button></a>
 		</div>
-			<s:form action="edit_confirm">
+		<s:form action="edit_confirm">
 			<div class="question_id_area">
 				<label>問題番号:</label>
 				<p><s:property value="questionId"/></p>
+				<s:hidden name="questionId" value="%{questionId}" />
 			</div>
 			<div class="question_form_area">
 				<label for="inputQuestion">問題:</label>

--- a/src/main/webapp/edit_confirm.jsp
+++ b/src/main/webapp/edit_confirm.jsp
@@ -1,0 +1,64 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<!-- Struts2のタグライブラリを使用可能にする -->
+<%@ taglib prefix="s" uri="/struts-tags"%>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<title>edit_confirm</title>
+		<style type="text/css">
+			body {width: 650px; margin: 0 auto;}
+			p {margin: 0;}
+			.btn_area {width: 100%; text-align: right;}
+			.bottom_btn_area {text-align: right; margin-top: 10px;}
+			label {margin-right: 10px;}
+			.question_area label, .answers_area label {width: 7%; text-align: right;}
+			.question_area {margin-top: 10px; display: flex;}
+			.question_area p {width: 87%; overflow-wrap: break-word;}
+			.answers_area {margin-top: 10px; display: flex;}
+			.answers {width: 87%;}
+			.answers p {overflow-wrap: break-word;}
+			.error {padding-top:10px;color: red;}
+			.question_id_area {display: flex;}
+			.edit_question_area label, .edit_answers_area label, .question_id_area label {width: 11%; text-align: right;}
+		</style>
+	</head>
+	<body>
+		<div class="btn_area">
+			<a href="<s:url action='top'/>"><button>top</button></a>
+			<a href="<s:url action='logout'/>"><button>logout</button></a>
+		</div>
+		<!-- エラーメッセージがある場合、エラーメッセージを表示  -->
+		<s:set var="errorMessage" value="errorMessage"/>
+		<s:if test="%{!#errorMessage.isEmpty()}">
+			<p class="error"><s:property escapeHtml="false" value="errorMessage"/></p>
+		</s:if>
+		<s:form action="edit_complete">
+			<div class="question_id_area">
+				<label>問題番号:</label>
+				<p><s:property value="questionId"/></p>
+			</div>
+			<div class="question_area">
+				<label>問題:</label>
+				<p><s:property value="inputQuestion"/></p>
+				<s:hidden name="inputQuestion" value="%{inputQuestion}"/>
+			</div>
+			<div class="answers_area">
+				<label>答え:</label>
+				<div class="answers">
+					<s:iterator value="inputAnswers">
+						<p><s:property /></p>
+					</s:iterator>
+					<s:hidden name="inputAnswers" value="%{inputAnswers}"/>
+				</div>
+			</div>
+			<div class="bottom_btn_area">
+				<button type="button" onclick="history.back()">戻る</button>
+				<!-- エラーメッセージがない場合、登録ボタンを表示  -->
+				<s:if test="%{#errorMessage.isEmpty()}">
+					<s:submit value = "登録"/>
+				</s:if>
+			</div>
+		</s:form>
+	</body>
+</html>

--- a/src/main/webapp/edit_confirm.jsp
+++ b/src/main/webapp/edit_confirm.jsp
@@ -58,7 +58,7 @@
 				<button type="button" onclick="history.back()">戻る</button>
 				<!-- エラーメッセージがない場合、登録ボタンを表示  -->
 				<s:if test="%{#errorMessage.isEmpty()}">
-					<s:submit value = "登録"/>
+					<s:submit value = "更新"/>
 				</s:if>
 			</div>
 		</s:form>

--- a/src/main/webapp/edit_confirm.jsp
+++ b/src/main/webapp/edit_confirm.jsp
@@ -37,6 +37,7 @@
 			<div class="question_id_area">
 				<label>問題番号:</label>
 				<p><s:property value="questionId"/></p>
+				<s:hidden name="questionId" value="%{questionId}"/>
 			</div>
 			<div class="question_area">
 				<label>問題:</label>
@@ -50,6 +51,7 @@
 						<p><s:property /></p>
 					</s:iterator>
 					<s:hidden name="inputAnswers" value="%{inputAnswers}"/>
+					<s:hidden name="answersId" value="%{answersId}"/>
 				</div>
 			</div>
 			<div class="bottom_btn_area">

--- a/src/main/webapp/list.jsp
+++ b/src/main/webapp/list.jsp
@@ -19,6 +19,8 @@
 			.list_question_area p {width: 80%; overflow: hidden; text-overflow: ellipsis;white-space: nowrap;}
 			.list_answers_area {margin-left: 20px;}
 			.list_answers_area p {overflow: hidden; text-overflow: ellipsis; white-space: nowrap;}
+			.list_btn_area {display: flex; width: 14%; justify-content: space-between;}
+			.list_btn_area a {text-decoration: none; position: relative; display: block;}
 		</style>
 	</head>
 	<body>
@@ -40,7 +42,7 @@
 						</s:iterator>
 					</div>
 				</div>
-				<div>
+				<div class="list_btn_area">
 				<!-- パラメータにquestionIdを設定 -->
 					<a href="<s:url action='edit'><s:param name="questionId" value="queList.get(#queSt.index).id" /></s:url>">
 						<button>編集</button>

--- a/src/main/webapp/register.jsp
+++ b/src/main/webapp/register.jsp
@@ -32,7 +32,7 @@
 				//答えの入力フォームを作成
 				var input = document.createElement('input');
 				input.type = 'text';
-				input.name = 'answers';
+				input.name = 'inputAnswers';
 				//削除ボタンを作成
 				var delete_btn = document.createElement('button');
 				delete_btn.type = 'button';

--- a/src/main/webapp/register.jsp
+++ b/src/main/webapp/register.jsp
@@ -70,7 +70,7 @@
 				<label for="inputAnswers">答え:</label>
 				<div class="answer_forms">
 					<div class="answer_form" id="answer_form1">
-						<s:textfield name = "inputAnswers"/>
+						<s:textfield name="inputAnswers"/>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
### 実装した機能
- 問題一覧画面の編集ボタンを押すと、画面に遷移するようにした。
- 編集画面では、問題フォームと、答えフォームを表示するようにした。（フォームのデフォルト値には、既存の値を設定）
- 編集画面では、追加ボタンを押すことで、答えフォームを追加できるようにした。（追加したフォームに関しては削除ボタンから削除可能）
- 編集画面では、確認ボタンを押すことで、編集確認画面に遷移するようにした。
- 編集確認画面では、編集画面で入力した値が表示されるようにした。
- 編集確認画面では、編集ボタンを押すことで、問題と答えが更新されるようにした。
- 編集画面で文字数制限等にエラーがあった場合、編集確認画面でエラーメッセージを表示し、更新ボタンを非表示氏にするようにした。
- 編集後は、問題一覧画面に遷移するようにした。

### 変更内容
- 編集画面と編集確認画面のjspファイルで作成。
- 編集画面を表示する処理、編集確認画面を表示する処理、編集処理として、actionクラスにメソッドを追加し、struts.xmlに設定を追加。
- Daoクラスに、答えIDから答えデータを取得する処理を追加。（以前は更新されていないデータも、更新日が更新されていたため、これを修正した。）
- 編集処理で、答えIDが必要となるため、それを格納する変数と、ゲッター、セッターを作成。