### PR TITLE
採点履歴表示機能を実装

### DIFF
--- a/resources/struts.xml
+++ b/resources/struts.xml
@@ -64,5 +64,9 @@
 			<result name="success">/result.jsp</result>
 			<result name="failure">/login.jsp</result>
 		</action>
+		<action name="history" class="kensyu3.controller.HistoriesAction" method="history">
+			<result name="success">/history.jsp</result>
+			<result name="failure">/login.jsp</result>
+		</action>
 	</package>
 </struts>

--- a/src/main/java/kensyu3/controller/HistoriesAction.java
+++ b/src/main/java/kensyu3/controller/HistoriesAction.java
@@ -2,6 +2,7 @@ package kensyu3.controller;
 
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Comparator;
 
 import kensyu3.model.HistoriesBean;
 import kensyu3.model.HistoriesDao;
@@ -13,6 +14,10 @@ public class HistoriesAction extends Base {
 	private ArrayList<HistoriesBean> hisList = new ArrayList<HistoriesBean>();
 	private String userName;
 	private String[] dateTime;
+	
+	/*
+	 *  アクションの定義
+	 */
 	
 	//採点結果履歴画面を表示
 	public String history() {
@@ -26,22 +31,40 @@ public class HistoriesAction extends Base {
 		}
 	}
 	
+	/*
+	 *  getterの定義
+	 */
+	
 	public ArrayList<HistoriesBean> getHisList() throws Exception{
-		HistoriesDao hisDao = new HistoriesDao();
-		hisList = hisDao.findByUserId((int)session.get("userId"));
+		//hisListに値が格納されていない場合
+		if (hisList.isEmpty()) {
+			HistoriesDao hisDao = new HistoriesDao();
+			//セッションに保存されているuserIdをもとに履歴のデータを取得
+			hisList = hisDao.findByUserId((int)session.get("userId"));
+			//履歴が採点日時の昇順に表示されるように、並び替えの条件を定義
+			Comparator<HistoriesBean> compare = Comparator.comparing(HistoriesBean::getCreatedAt);
+			//指定した条件で並び替える
+			hisList.sort(compare);
+		}
 		return hisList;
 	}
 	
 	public String getUserName() throws Exception{
-		UsersDao usersDao = new UsersDao();
-		UsersBean user = usersDao.findById((int)session.get("userId"));
-		userName = user.getName();
+		//userNameに値が格納されていない場合
+		if (userName == null) {
+			UsersDao usersDao = new UsersDao();
+			//セッションに保存されているuserIdをもとにユーザー名を取得
+			UsersBean user = usersDao.findById((int)session.get("userId"));
+			userName = user.getName();
+		}
 		return userName;
 	}
 	
 	public String[] getDateTime() throws Exception{
+		//フォーマットを作成
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
 		dateTime = new String[hisList.size()];
+		//履歴データから作成日を取り出し、配列にする
 		for(int i = 0 ; i < dateTime.length; i++) {
 			dateTime[i] = sdf.format(hisList.get(i).getCreatedAt());
 		}

--- a/src/main/java/kensyu3/controller/HistoriesAction.java
+++ b/src/main/java/kensyu3/controller/HistoriesAction.java
@@ -1,6 +1,18 @@
 package kensyu3.controller;
 
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+
+import kensyu3.model.HistoriesBean;
+import kensyu3.model.HistoriesDao;
+import kensyu3.model.UsersBean;
+import kensyu3.model.UsersDao;
+
 public class HistoriesAction extends Base {
+	//jspファイルから受け取る値の定義
+	private ArrayList<HistoriesBean> hisList = new ArrayList<HistoriesBean>();
+	private String userName;
+	private String[] dateTime;
 	
 	//採点結果履歴画面を表示
 	public String history() {
@@ -12,6 +24,28 @@ public class HistoriesAction extends Base {
 			//login画面に遷移
 			return "failure";
 		}
+	}
+	
+	public ArrayList<HistoriesBean> getHisList() throws Exception{
+		HistoriesDao hisDao = new HistoriesDao();
+		hisList = hisDao.findByUserId((int)session.get("userId"));
+		return hisList;
+	}
+	
+	public String getUserName() throws Exception{
+		UsersDao usersDao = new UsersDao();
+		UsersBean user = usersDao.findById((int)session.get("userId"));
+		userName = user.getName();
+		return userName;
+	}
+	
+	public String[] getDateTime() throws Exception{
+		SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+		dateTime = new String[hisList.size()];
+		for(int i = 0 ; i < dateTime.length; i++) {
+			dateTime[i] = sdf.format(hisList.get(i).getCreatedAt());
+		}
+		return dateTime;
 	}
 
 }

--- a/src/main/java/kensyu3/controller/HistoriesAction.java
+++ b/src/main/java/kensyu3/controller/HistoriesAction.java
@@ -1,0 +1,17 @@
+package kensyu3.controller;
+
+public class HistoriesAction extends Base {
+	
+	//採点結果履歴画面を表示
+	public String history() {
+		//Baseクラスでログインしているかどうかを確認
+		if (super.isCheckLogin()) {
+			//history画面に遷移
+			return "success" ;
+		}else {
+			//login画面に遷移
+			return "failure";
+		}
+	}
+
+}

--- a/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
+++ b/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
@@ -245,7 +245,7 @@ public class QuestionsAnswersAction extends Base{
 	
 	//全問題のgetter
 	public ArrayList<QuestionsBean> getQueList() throws Exception {
-		//queListが空だった場合
+		//queListに値が格納されていない場合
 		if (queList.isEmpty()) {
 			QuestionsDao queDao = new QuestionsDao();
 			//問題データを全件取得
@@ -256,7 +256,7 @@ public class QuestionsAnswersAction extends Base{
 	
 	//全答えのgetter
 	public ArrayList<ArrayList<AnswersBean>> getAnsList() throws Exception{
-		//ansListが空だった場合
+		//ansListに値が格納されていない場合
 		if (ansList.isEmpty()) {
 			AnswersDao ansDao = new AnswersDao();
 			//答えデータを全件取得
@@ -270,7 +270,7 @@ public class QuestionsAnswersAction extends Base{
 	
 	//ランダムな問題のgetter
 	public ArrayList<QuestionsBean> getRandomQueList() throws Exception {
-		//randomQueListが空だった場合
+		//randomQueListに値が格納されていない場合
 		if (randomQueList.isEmpty()) {
 			QuestionsDao queDao = new QuestionsDao();
 			//問題データを全件取得
@@ -283,7 +283,7 @@ public class QuestionsAnswersAction extends Base{
 	
 	//問題のgetter
 	public String getQuestion() throws Exception{
-		//questionがnullだった場合
+		//questionに値が格納されていない場合
 		if (question == null) {
 			QuestionsDao queDao = new QuestionsDao();
 			//questionIdから問題文データを取得
@@ -296,7 +296,7 @@ public class QuestionsAnswersAction extends Base{
 	
 	//答えのgetter
 	public String[] getAnswers() throws Exception {
-		//answersがnullだった場合
+		//answersに値が格納されていない場合
 		if (answers == null) {
 			AnswersDao ansDao = new AnswersDao();
 			//questionIdから答えのデータを取得
@@ -322,7 +322,7 @@ public class QuestionsAnswersAction extends Base{
 	
 	//答えidのgetter
 	public int[] getAnswersId() throws Exception{
-		//answersIdが0だった場合
+		//answersIdに値が格納されていない場合
 		if (answersId == null) {
 			AnswersDao ansDao = new AnswersDao();
 			//questionIdから答えデータを取得
@@ -389,7 +389,7 @@ public class QuestionsAnswersAction extends Base{
 	
 	//現在ログインしているユーザー名のgetter
 	public String getUserName() throws Exception{
-		//userNameが空だった場合
+		//userNameに値が格納されていない場合
 		if(userName == null) {
 			UsersDao usersDao = new UsersDao();
 			//セッションに登録されているidをもとに、ユーザーを取得
@@ -402,11 +402,14 @@ public class QuestionsAnswersAction extends Base{
 	
 	//現在日時のgetter
 	public String getCurrentDateTime() {
-		//現在の日時をtimestampに格納
-		Timestamp timestamp = new Timestamp(System.currentTimeMillis());
-		//日時のフィーマットを指定
-		SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
-		currentDateTime = sdf.format(timestamp);
+		//currentDateTimeに値が格納されていない場合
+		if(currentDateTime == null) {
+			//現在の日時をtimestampに格納
+			Timestamp timestamp = new Timestamp(System.currentTimeMillis());
+			//日時のフィーマットを指定
+			SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
+			currentDateTime = sdf.format(timestamp);
+		}
 		return currentDateTime;
 	}
 

--- a/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
+++ b/src/main/java/kensyu3/controller/QuestionsAnswersAction.java
@@ -204,7 +204,7 @@ public class QuestionsAnswersAction extends Base{
 		}
 	}
 	
-	//履歴の登録と採点結果履歴画面の表示
+	//履歴の登録処理と採点結果履歴画面の表示
 	public String result() throws Exception{
 		//Baseクラスでログインしているかどうかを確認
 		if (super.isCheckLogin()) {
@@ -226,6 +226,7 @@ public class QuestionsAnswersAction extends Base{
 			}
 			//点数を計算
 			point = Math.round(100 * correctCnt / questionsId.length);
+			
 			HistoriesDao hisDao = new HistoriesDao();
 			//履歴を登録
 			hisDao.register((int)session.get("userId"), point);
@@ -300,14 +301,11 @@ public class QuestionsAnswersAction extends Base{
 			AnswersDao ansDao = new AnswersDao();
 			//questionIdから答えのデータを取得
 			ArrayList<AnswersBean> ans = ansDao.findByQuestionId(questionId);
-			//答えを一時的に入れる配列
-			String[] tmpAnswers = new String[ans.size()];
+			answers = new String[ans.size()];
 			for(int i = 0; i < ans.size(); i++) {
 				//答えデータから答えを取得し、配列に格納
-				tmpAnswers[i] = ans.get(i).getAnswer();
+				answers[i] = ans.get(i).getAnswer();
 			}
-			//answersに配列となった答えを入れ直す
-			answers = tmpAnswers;
 		}
 		return answers;
 	}
@@ -329,14 +327,11 @@ public class QuestionsAnswersAction extends Base{
 			AnswersDao ansDao = new AnswersDao();
 			//questionIdから答えデータを取得
 			ArrayList<AnswersBean> ans = ansDao.findByQuestionId(questionId);
-			//答えidを一時的に入れる配列
-			int[] tmpAnswersId = new int[ans.size()];
+			answersId = new int[ans.size()];
 			for(int i = 0; i < ans.size(); i++) {
 				//答えデータから答えを取得し、配列に格納
-				tmpAnswersId[i] = ans.get(i).getId();
+				answersId[i] = ans.get(i).getId();
 			}
-			//aanswersに配列になっている答えを入れ直す
-			answersId = tmpAnswersId;
 		}
 		return answersId;
 	}
@@ -356,7 +351,6 @@ public class QuestionsAnswersAction extends Base{
 	public int[] getQuestionsId() {
 		return questionsId;
 	}
-	
 	
 	//フォームから入力した問題のgetter
 	public String getInputQuestion() {
@@ -383,7 +377,6 @@ public class QuestionsAnswersAction extends Base{
 		return errorMessage;
 	}
 	
-	
 	//点数のgetter
 	public int getPoint() {
 		return point;
@@ -396,9 +389,14 @@ public class QuestionsAnswersAction extends Base{
 	
 	//現在ログインしているユーザー名のgetter
 	public String getUserName() throws Exception{
-		UsersDao usersDao = new UsersDao();
-		UsersBean user = usersDao.findById((int)session.get("userId"));
-		userName = user.getName();
+		//userNameが空だった場合
+		if(userName == null) {
+			UsersDao usersDao = new UsersDao();
+			//セッションに登録されているidをもとに、ユーザーを取得
+			UsersBean user = usersDao.findById((int)session.get("userId"));
+			//ユーザー情報からユーザー名を取得し、格納
+			userName = user.getName();
+		}
 		return userName;
 	}
 	
@@ -409,7 +407,6 @@ public class QuestionsAnswersAction extends Base{
 		//日時のフィーマットを指定
 		SimpleDateFormat sdf = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss");
 		currentDateTime = sdf.format(timestamp);
-		//yyyy/MM/dd 形式の現在日時を返す
 		return currentDateTime;
 	}
 

--- a/src/main/java/kensyu3/model/HistoriesBean.java
+++ b/src/main/java/kensyu3/model/HistoriesBean.java
@@ -1,0 +1,76 @@
+package kensyu3.model;
+
+import java.sql.Timestamp;
+
+public class HistoriesBean {
+	private int id;
+	private int user_id;
+	private int point;
+	private Timestamp created_at;
+	private byte deleteflag; 
+	private Timestamp deleted_at;
+
+	/**
+	 * コンストラクタで、id、user_id、point、created_atに値をセット
+	 */
+	public HistoriesBean (int id, int user_id, int point, Timestamp created_at){
+		this.id = id;
+		this.user_id = user_id;
+		this.point = point;
+		this.created_at = created_at;
+	}
+	
+	/** 引数無しのコンストラクタ **/
+	public HistoriesBean() {
+	}
+	
+	//メンバ変数のidを取得
+	public int getId() {
+		return this.id;
+	}
+	
+	//メンバ変数のidに値をセット
+	public void setId(int id) {
+		this.id = id;
+	}
+	
+	//メンバ変数のuser_idを取得
+	public int getUserId() {
+		return this.user_id;
+	}
+	
+	//メンバ変数のuser_idに値をセット
+	public void setUserId(int user_id) {
+		this.user_id = user_id;
+	}
+	
+	//メンバ変数のpointを取得
+	public int getPoint() {
+		return this.point;
+	}
+	
+	//メンバ変数のpointに値をセット
+	public void setPoint(int point) {
+		this.point = point;
+	}
+	
+	//メンバ変数のcreated_atを取得
+	public Timestamp getCreatedAt() {
+		return this.created_at;
+	}
+	
+	//メンバ変数のcreated_atに値をセット
+	public void setCreatedAt(Timestamp created_at) {
+		this.created_at = created_at;
+	}
+	
+	//メンバ変数のdeleteflagを取得
+	public byte getDeleteflag() {
+		return this.deleteflag;
+	}
+	
+	//メンバ変数のdeleteflagに値をセット
+	public void setDeleteflag(byte deleteflag) {
+		this.deleteflag = deleteflag;
+	}
+}

--- a/src/main/java/kensyu3/model/HistoriesDao.java
+++ b/src/main/java/kensyu3/model/HistoriesDao.java
@@ -1,0 +1,86 @@
+package kensyu3.model;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+
+public class HistoriesDao extends ConnectionDao {
+	
+	/**
+	 * コンストラクタ（戻り値のない）
+	 */
+	public HistoriesDao() throws Exception {
+		//DBと接続する
+		setConnection();
+	}
+	
+	/**
+	 * 指定IDのレコードを取得する
+	 */
+	public ArrayList<HistoriesBean> search_userId(int currentUserId) throws Exception {
+		//DBと接続がない場合、接続
+		if (con == null) {
+			setConnection();
+		}
+		//histories からidとuser_id, point, created_atを取得（条件：deleted_atが空で、user_idが一致するもの）
+		String sql = "SELECT id, user_id, point, created_at FROM histories WHERE deleted_at is null and user_id = ? ";
+		
+		/** PreparedStatement オブジェクトの取得**/
+		try(PreparedStatement st = con.prepareStatement(sql)) {	
+			//sqlの ? に値をセット
+			st.setInt(1, currentUserId);
+			/** SQL 実行 **/
+			ResultSet rs = st.executeQuery();
+			/** select文の結果をArrayListに格納 **/ 
+			ArrayList<HistoriesBean> list = new ArrayList<HistoriesBean>();
+			
+			//実行結果を一行ずつ読み込む
+			while (rs.next()) {
+				//実行結果からデータを取得し、各フィールドに格納
+				int id = rs.getInt("id");
+				int userId = rs.getInt("user_id");
+				int point = rs.getInt("point");
+				Timestamp createdAt = rs.getTimestamp("created_at");
+				//オブジェクトを作成し、コンストラクタに値を渡す
+				HistoriesBean bean = new HistoriesBean(id, userId, point, createdAt);
+				//listにオブジェクトを追加
+				list.add(bean);
+			}
+			//listを返す（実行結果があればオブジェクトが格納されているが、実行結果がなければ空）
+			return list;
+		} catch (Exception e) {
+			//スタックトレースを出力
+			e.printStackTrace();
+			//例外を投げる
+			throw new DAOException("レコードの取得に失敗しました");
+		}
+	}
+	
+	/**
+	 * 履歴を登録する
+	 */
+	public void register_history(int userId, int point) throws Exception {
+		//DBと接続がない場合、接続
+		if (con == null) {
+			setConnection();
+		}
+		//histories にデータを追加
+		String sql = "INSERT INTO histories (user_id, point, created_at) VALUES (?, ?,  CURRENT_TIMESTAMP());";
+		
+		/** PreparedStatement オブジェクトの取得**/
+		try(PreparedStatement st = con.prepareStatement(sql)) {
+			//sqlの ? に値をセット
+			st.setInt(1, userId);
+			st.setInt(2, point);
+			/** SQL 実行 **/
+			st.executeUpdate();
+		} catch (Exception e) {
+			//スタックトレースを出力
+			e.printStackTrace();
+			//例外を投げる
+			throw new DAOException("レコードの登録に失敗しました");
+		}
+	}
+
+}

--- a/src/main/java/kensyu3/model/HistoriesDao.java
+++ b/src/main/java/kensyu3/model/HistoriesDao.java
@@ -16,9 +16,9 @@ public class HistoriesDao extends ConnectionDao {
 	}
 	
 	/**
-	 * 指定IDのレコードを取得する
+	 * 指定useridのレコードを取得する
 	 */
-	public ArrayList<HistoriesBean> search_userId(int currentUserId) throws Exception {
+	public ArrayList<HistoriesBean> findByUserId(int currentUserId) throws Exception {
 		//DBと接続がない場合、接続
 		if (con == null) {
 			setConnection();

--- a/src/main/java/kensyu3/model/HistoriesDao.java
+++ b/src/main/java/kensyu3/model/HistoriesDao.java
@@ -60,7 +60,7 @@ public class HistoriesDao extends ConnectionDao {
 	/**
 	 * 履歴を登録する
 	 */
-	public void register_history(int userId, int point) throws Exception {
+	public void register(int userId, int point) throws Exception {
 		//DBと接続がない場合、接続
 		if (con == null) {
 			setConnection();

--- a/src/main/webapp/history.jsp
+++ b/src/main/webapp/history.jsp
@@ -1,0 +1,56 @@
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<!-- Struts2のタグライブラリを使用可能にする -->
+<%@ taglib prefix="s" uri="/struts-tags"%>
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+		<title>history</title>
+		<style type="text/css">
+			body {width: 650px; margin: 0 auto;}
+			p {margin: 0;}
+			.btn_area {width: 100%; text-align: right; margin-top: 10px;}
+			label {margin-right: 10px;}
+			.new_btn {text-decoration: none; position: relative; width: 10%; padding: 12px 3px; display: block; margin: 10px auto;}
+			.new_btn button {position: absolute; inset: 0;}
+			.list_area {margin-bottom: 10px; display: flex;}
+			.list {width: 84.5%;}
+			.list_question_area {display: flex; margin-bottom: 5px;}
+			.list_question_area p {width: 80%; overflow: hidden; text-overflow: ellipsis;white-space: nowrap;}
+			.list_answers_area {margin-left: 20px;}
+			.list_answers_area p {overflow: hidden; text-overflow: ellipsis; white-space: nowrap;}
+			.list_btn_area {display: flex; width: 14%; justify-content: space-between;}
+			.list_btn_area a {text-decoration: none; position: relative; display: block;}
+		</style>
+	</head>
+	<body>
+		<div class="btn_area">
+			<a href="<s:url action='top'/>"><button>top</button></a>
+			<a href="<s:url action='logout'/>"><button>logout</button></a>
+		</div>
+		<h2>履歴</h2>
+		<!-- 履歴が登録されていない場合  -->
+		<s:set var="hisList" value="hisList"/>
+		<s:if test="%{#hisList.isEmpty()}">
+			<p>履歴が登録されていません</p>
+		</s:if>
+		<!-- 履歴が登録されている場合  -->
+		<s:else>
+			<table>
+				 <tr>
+				 	<th>氏名</th>
+				 	<th>得点</th>
+				 	<th>採点時間</th>
+				 </tr>
+				 <s:iterator value="%{hisList}">
+					 <tr>
+					 	<!-- ユーザー名を表示  -->
+					 	<td><s:property value="userName"/></td>
+					 	<td><s:property value="point"/>点</td>
+					 	<td><s:property value="sdf.format(createdAt())"/></td>
+					 </tr>
+				</s:iterator>
+			</table>
+		<s:else>
+	</body>
+</html>

--- a/src/main/webapp/history.jsp
+++ b/src/main/webapp/history.jsp
@@ -1,4 +1,4 @@
-<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8"%>
+<%@ page language="java" contentType="text/html; charset=UTF-8" pageEncoding="UTF-8" %>
 <!-- Struts2のタグライブラリを使用可能にする -->
 <%@ taglib prefix="s" uri="/struts-tags"%>
 <!DOCTYPE html>
@@ -42,15 +42,15 @@
 				 	<th>得点</th>
 				 	<th>採点時間</th>
 				 </tr>
-				 <s:iterator value="%{hisList}">
+				 <s:iterator value="%{hisList}" status="hisSt">
 					 <tr>
 					 	<!-- ユーザー名を表示  -->
 					 	<td><s:property value="userName"/></td>
 					 	<td><s:property value="point"/>点</td>
-					 	<td><s:property value="sdf.format(createdAt())"/></td>
+					 	<td><s:property value="dateTime[#hisSt.index]"/></td>
 					 </tr>
 				</s:iterator>
 			</table>
-		<s:else>
+		</s:else>
 	</body>
 </html>

--- a/src/main/webapp/history.jsp
+++ b/src/main/webapp/history.jsp
@@ -10,17 +10,9 @@
 			body {width: 650px; margin: 0 auto;}
 			p {margin: 0;}
 			.btn_area {width: 100%; text-align: right; margin-top: 10px;}
-			label {margin-right: 10px;}
-			.new_btn {text-decoration: none; position: relative; width: 10%; padding: 12px 3px; display: block; margin: 10px auto;}
 			.new_btn button {position: absolute; inset: 0;}
-			.list_area {margin-bottom: 10px; display: flex;}
-			.list {width: 84.5%;}
-			.list_question_area {display: flex; margin-bottom: 5px;}
-			.list_question_area p {width: 80%; overflow: hidden; text-overflow: ellipsis;white-space: nowrap;}
-			.list_answers_area {margin-left: 20px;}
-			.list_answers_area p {overflow: hidden; text-overflow: ellipsis; white-space: nowrap;}
-			.list_btn_area {display: flex; width: 14%; justify-content: space-between;}
-			.list_btn_area a {text-decoration: none; position: relative; display: block;}
+			table {border-collapse: collapse;}
+			td, th {padding: 7px; width: 210px; border: solid 1px;}
 		</style>
 	</head>
 	<body>

--- a/src/main/webapp/history.jsp
+++ b/src/main/webapp/history.jsp
@@ -36,7 +36,6 @@
 				 </tr>
 				 <s:iterator value="%{hisList}" status="hisSt">
 					 <tr>
-					 	<!-- ユーザー名を表示  -->
 					 	<td><s:property value="userName"/></td>
 					 	<td><s:property value="point"/>点</td>
 					 	<td><s:property value="dateTime[#hisSt.index]"/></td>

--- a/src/main/webapp/result.jsp
+++ b/src/main/webapp/result.jsp
@@ -24,7 +24,7 @@
 		<h2>テスト結果</h2>
 		<p><s:property value="userName"/>さん</p>
 		<p>${queCnt}問中<s:property value="correctCnt"/>問正解です。</p>
-		<p><s:property value="score"/>点でした。</p>
+		<p><s:property value="point"/>点でした。</p>
 		<div class="bottom_menu_area">
 			<p><s:property value="currentDateTime"/></p>
 			<a href="<s:url action='history'/>">採点結果履歴へ</a>


### PR DESCRIPTION
### 実装した機能
- 採点結果画面の「採点結果履歴へ」ボタンやトップ画面の「過去の採点結果を見る」ボタンを押すと、採点結果履歴画面に遷移するようにした。
- 採点結果履歴画面では、現在ログインしているユーザーの履歴を、採点時間の昇順で表示するようにした。
- 採点結果履歴画面では、ユーザー名と得点、採点時間を表形式で表示するようにした。

### 変更内容
- 採点結果履歴画面をjspファイルで作成。
- 採点結果画面を表示する際の処理として、actionクラスにメソッドを追加し、struts.xmlに設定を追加。
- 採点結果画面で表示するユーザー名、採点日、履歴データを格納する変数を作成し、ゲッターを作成。
- 採点結果履歴をDBに格納するため、historiesテーブルのデータを格納するBeanクラスと、historiesテーブルのデータのCRUDを行うDaoクラスを作成。
- テスト画面において、得点を格納する変数名を変更。
- テスト画面表示処理内で、履歴の登録をするようにした。
- 履歴の登録をする際、点数が正しく取得できないエラーを修正するため、採点処理や正答数のカウントは、getterではなく、テスト画面表示処理内で行うようにした。
